### PR TITLE
904 & 905: Register page improvements

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -27,6 +27,7 @@
         "react-scripts": "^5.0.1",
         "react-toastify": "^10.0.4",
         "styled-components": "^6.1.8",
+        "validator": "^13.11.0",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -17944,6 +17945,14 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
+    "node_modules/validator": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -31560,6 +31569,11 @@
           "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
         }
       }
+    },
+    "validator": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ=="
     },
     "vary": {
       "version": "1.1.2",

--- a/client/package.json
+++ b/client/package.json
@@ -22,6 +22,7 @@
     "react-scripts": "^5.0.1",
     "react-toastify": "^10.0.4",
     "styled-components": "^6.1.8",
+    "validator": "^13.11.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/client/src/components/Register.js
+++ b/client/src/components/Register.js
@@ -1,6 +1,6 @@
 import Typography from '@mui/material/Typography';
 import Input from '@mui/material/Input';
-import {useState} from 'react'
+import { useState } from 'react'
 import { useNavigate } from "react-router-dom";
 import { Button } from '@mui/material';
 import Box from '@mui/material/Box';
@@ -9,6 +9,7 @@ import '../styles/Register.css';
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import OutlinedInput from '@mui/material/OutlinedInput';
+import validator, { isAlphaLocales } from 'validator';
 
 const Register = () => {
     let navigate = useNavigate();
@@ -16,9 +17,14 @@ const Register = () => {
     const [member, setMember] = useState({})
     const [err, setErr] = useState('')
 
+    // States for storing input validation results
+    const [emailValid, setEmailValid] = useState(true);
+    const [phoneValid, setPhoneValid] = useState(true);
+    const [postalValid, setPostalValid] = useState(true);
+
     //Keeps track of the input fields and creates the member object as the fields are being filled.
     const whenChanging = (event) => {
-        setMember({...member, [event.target.id]: event.target.value})
+        setMember({ ...member, [event.target.id]: event.target.value })
     }
 
     //Sends the member object to server
@@ -35,36 +41,29 @@ const Register = () => {
         })
             .then(response => response.json())
             .then(data => {
-                if(data.success) 
-                {
+                if (data.success) {
                     navigate('/login');
                 }
-                else 
-                {
-                    if(data.errors !== undefined) 
-                    {
-                        if (data.errors[0] !== undefined) 
-                        {
+                else {
+                    if (data.errors !== undefined) {
+                        if (data.errors[0] !== undefined) {
                             setErr(data.errors[0].msg);
                             showToastMessage(data.errors[0].msg);
-                        } 
-                        else if (data.errors[1] !== undefined) 
-                        {
+                        }
+                        else if (data.errors[1] !== undefined) {
                             setErr(data.errors[1].msg);
                             showToastMessage(data.errors[1].msg);
                         }
-                    } 
-                    else 
-                    {
+                    }
+                    else {
                         setErr(data.message);
                         showToastMessage(data.message);
                     }
                 }
-        })
+            })
     }
 
-    const showToastMessage = (message) =>
-    {
+    const showToastMessage = (message) => {
         toast.error(message, {
             position: "top-center",
             autoClose: 3000,
@@ -74,27 +73,56 @@ const Register = () => {
             draggable: false,
             progress: undefined,
             theme: "dark"
-            });
+        });
     }
+
+    const validatePhone = (event) => {
+        if (event.target.value !== "" && !validator.isMobilePhone(event.target.value)) {
+            showToastMessage("Please input a valid phone number.");
+            setPhoneValid(false);
+        } else {
+            setPhoneValid(true);
+        }
+    }
+
+    const validateEmail = (event) => {
+        if (event.target.value !== "" && !validator.isEmail(event.target.value)) {
+            showToastMessage("Please input a valid email.");
+            setEmailValid(false);
+        } else {
+            setEmailValid(true);
+        }
+    }
+
+    const validatePostalCode = (event) => {
+        if (event.target.value !== "" && !validator.isPostalCode(event.target.value, "FI")) {
+            showToastMessage("Please input a valid postal code.");
+            setPostalValid(false);
+        } else {
+            setPostalValid(true);
+        }
+    }
+
 
     return (
         <div className='RegisterBackground'>
             <h1>Register</h1>
 
             <form onSubmit={submitForm} onChange={whenChanging} className='RegisterForm' >
-                <OutlinedInput fullWidth required placeholder={'First name'} type="text" id="firstname" sx={{m: 1}} />
-                <OutlinedInput fullWidth required placeholder={'Last name'} type="text" id="lastname" sx={{m: 1}} />
-                <OutlinedInput fullWidth required placeholder={'Phone number'} type="text" id="phone" sx={{m: 1}} />
-                <OutlinedInput fullWidth required placeholder={'Address'} type="text" id="address" sx={{m: 1}} />
-                <OutlinedInput fullWidth required placeholder={'Postal code'} type="text" id="postalcode" sx={{m: 1}} />
-                <OutlinedInput fullWidth required placeholder={'City'} type="text" id="city" sx={{m: 1}} />
-                <OutlinedInput fullWidth required placeholder={'Country'} type="text" id="country" sx={{m: 1}} />
-                <OutlinedInput fullWidth required placeholder={'Email'} type="email" id="email" sx={{m: 1}} />
-                <p className='HintParagraphSmall'>The password must have upper- and lowercase characters, a number, a symbol and be 10 characters long.</p>
-                <OutlinedInput fullWidth required placeholder={'Password'} type="password" id="password" sx={{m: 1}} />
-                <Button variant='contained' type="submit" id="submit" sx={{m: 1}} >Register</Button>
+                <p className='HintParagraphSmall'>All fields are required.</p>
+                <OutlinedInput fullWidth required placeholder={'First name'} type="text" id="firstname" sx={{ m: 1 }} />
+                <OutlinedInput fullWidth required placeholder={'Last name'} type="text" id="lastname" sx={{ m: 1 }} />
+                <OutlinedInput error={!phoneValid} fullWidth required placeholder={'Phone number'} type="text" id="phone" sx={{ m: 1 }} onBlur={validatePhone} />
+                <OutlinedInput fullWidth required placeholder={'Address'} type="text" id="address" sx={{ m: 1 }} />
+                <OutlinedInput error={!postalValid} fullWidth required placeholder={'Postal code'} type="text" id="postalcode" sx={{ m: 1 }} onBlur={validatePostalCode} />
+                <OutlinedInput fullWidth required placeholder={'City'} type="text" id="city" sx={{ m: 1 }} />
+                <OutlinedInput fullWidth required placeholder={'Country'} type="text" id="country" sx={{ m: 1 }} />
+                <OutlinedInput error={!emailValid} fullWidth required placeholder={'Email'} type="email" id="email" sx={{ m: 1 }} onBlur={validateEmail} />
+                <p className='HintParagraphSmall'>The password must have upper- and lowercase characters, a number, a symbol and be at least 10 characters long.</p>
+                <OutlinedInput fullWidth required placeholder={'Password'} type="password" id="password" sx={{ m: 1 }} />
+                <Button variant='contained' type="submit" id="submit" sx={{ m: 1 }} >Register</Button>
             </form>
-        
+
             {/* If there would be an error with registeration it would be shown here */}
             <ToastContainer />
         </div>


### PR DESCRIPTION
Added input validation for the email, phone number and postal code fields, using the npm `validator` package. If the input for one of these fields is invalid, a toast is shown and the corresponding field is highlighted. Also added a note that all fields are required.

Also my linter changed the spacing of some of the code but that's just aeastetic, i guess i should figure out how to unify the styles..