### PR TITLE
Asynchronous user authentication

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -9,6 +9,7 @@ import Login from './components/Login';
 import { useState, useEffect } from 'react';
 
 function App() {
+  const [loading, setLoading] = useState(true);
   const [currentUser, setCurrentUser] = useState({
     admin: false,
     loggedIn: false,
@@ -38,33 +39,41 @@ function App() {
 
   useEffect(() =>
   {
-    const tokenFromStorage = localStorage.getItem('AssocEase_Token');
-    if (tokenFromStorage != null)
+    const tokenFromStorage = localStorage.getItem("AssocEase_Token");
+    async function authenticate()
     {
-      fetch('/api/authenticate/token', {
-        method: 'POST',
+      setLoading(true);
+      await fetch("/api/authenticate/token", {
+        method: "POST",
         headers: {
-          'Content-type': 'application/json'
+          "Content-type": "application/json",
         },
-        body: JSON.stringify({token: tokenFromStorage}),
+        body: JSON.stringify({ token: tokenFromStorage }),
       })
-      .then(response => response.json())
-      .then((data) =>
-      {
-        if (data.success)
+        .then((response) => response.json())
+        .then((data) =>
         {
-          setCurrentUser({
-            admin: data.admin,
-            loggedIn: true,
-            token: tokenFromStorage,
-            id: data.id
-          });
-        }
-      });
+          if (data.success)
+          {
+            setCurrentUser({
+              admin: data.admin,
+              loggedIn: true,
+              token: tokenFromStorage,
+              firstname: data.firstname,
+              lastname: data.lastname,
+              id: data.id,
+            });
+          }
+        });
+      setLoading(false);
+    }
+    if (tokenFromStorage !== null)
+    {
+      authenticate();
     }
   }, []);
 
-  return (
+  if (!loading) return (
     <ThemeProvider theme={theme}>
       <Router>
         <div className="App">


### PR DESCRIPTION
Added async/await to our user authentication logic so that we don't have issues where the authentication isn't done yet, but something that requires authentication is rendered. Noticed this while testing Jesse's events changes, where refreshing the home page messes up the events. This also happens on the members page.

I included `firstname` and `lastname` for the user so that these changes don't cause conflicts with Jesse's branch when merging the branches.