### PR TITLE
Events fetch

### DIFF
--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -231,7 +231,7 @@ function Home(props) {
   }, [updateEvents])
 
   // POST new event
-  const saveNewEventOnClick = (e) => {
+  const saveNewEventOnClick = async (e) => {
     e.preventDefault()
     if(!startTimeError && newEvent.startDate) {
       if(!endTimeError) {
@@ -245,7 +245,7 @@ function Home(props) {
             newEvent.attendees = 1;
             
             setNewEvent(newEvent);
-            fetch("/api/event", {
+            await fetch("/api/event", {
               method: "POST",
               headers: {
                   "Content-type": "application/json",

--- a/client/src/components/MyProfile.js
+++ b/client/src/components/MyProfile.js
@@ -259,38 +259,38 @@ function MyProfile(props) {
     // Fetches the events the user is currently participating in
     // TODO; this currently only includes events the user created themselves
 
-    // fetchUsersEvents();
+    fetchUsersEvents();
     
     // Create events for testing
-    setEvents([
-      {
-        title: "TechSynergy Summit",
-        creator: "Emily Thompson",
-        time: "26.2.2024 12:00",
-        location: "LUT University",
-        attendees: 41,
-        attending: true,
-        description: `The TechSynergy Summit is a premier corporate event designed to bring together industry leaders, visionaries, and innovators in the ever-evolving landscape of technology. This exclusive summit serves as a dynamic platform or collaboration, knowledge exchange, and networking. Attendees can expect insightful keynote presentations, interactive panel discussions, and hands-on workshops that explore the intersection of cutting-edge technologies, fostering an environment where ideas converge, and innovation thrives. Join us at TechSynergy Summit to be at the forefront of the technological revolution and cultivate meaningful connections that propel your organization into the future.`,
-      },
-      {
-        title: "FutureTech Showcase",
-        creator: "Liam Patel",
-        time: "2.4.2024 14:00",
-        location: "LUT University",
-        attendees: 24,
-        attending: true,
-        description: `Step into the future with FutureTech Showcase, where cutting-edge innovations and breakthrough technologies converge. Explore the latest advancements in robotics, artificial intelligence, and beyond. Immerse yourself in a curated exhibition that unveils tomorrow's tech landscape today.`,
-      },
-      {
-        title: "Digital Nexus Symposium",
-        creator: "Sophia Mitchell",
-        time: "18.7.2024 10:00",
-        location: "LUT University",
-        attendees: 98,
-        attending: true,
-        description: `Join thought leaders and industry experts at the Digital Nexus Symposium, a dynamic gathering that explores the interconnected world of digital technologies. Engage in insightful discussions on the impact of AI, data analytics, and cyber-physical systems. Discover the converging points shaping our digital future at this symposium of ideas and collaboration.`,
-      },
-    ]);
+    // setEvents([
+    //   {
+    //     title: "TechSynergy Summit",
+    //     creator: "Emily Thompson",
+    //     time: "26.2.2024 12:00",
+    //     location: "LUT University",
+    //     attendees: 41,
+    //     attending: true,
+    //     description: `The TechSynergy Summit is a premier corporate event designed to bring together industry leaders, visionaries, and innovators in the ever-evolving landscape of technology. This exclusive summit serves as a dynamic platform or collaboration, knowledge exchange, and networking. Attendees can expect insightful keynote presentations, interactive panel discussions, and hands-on workshops that explore the intersection of cutting-edge technologies, fostering an environment where ideas converge, and innovation thrives. Join us at TechSynergy Summit to be at the forefront of the technological revolution and cultivate meaningful connections that propel your organization into the future.`,
+    //   },
+    //   {
+    //     title: "FutureTech Showcase",
+    //     creator: "Liam Patel",
+    //     time: "2.4.2024 14:00",
+    //     location: "LUT University",
+    //     attendees: 24,
+    //     attending: true,
+    //     description: `Step into the future with FutureTech Showcase, where cutting-edge innovations and breakthrough technologies converge. Explore the latest advancements in robotics, artificial intelligence, and beyond. Immerse yourself in a curated exhibition that unveils tomorrow's tech landscape today.`,
+    //   },
+    //   {
+    //     title: "Digital Nexus Symposium",
+    //     creator: "Sophia Mitchell",
+    //     time: "18.7.2024 10:00",
+    //     location: "LUT University",
+    //     attendees: 98,
+    //     attending: true,
+    //     description: `Join thought leaders and industry experts at the Digital Nexus Symposium, a dynamic gathering that explores the interconnected world of digital technologies. Engage in insightful discussions on the impact of AI, data analytics, and cyber-physical systems. Discover the converging points shaping our digital future at this symposium of ideas and collaboration.`,
+    //   },
+    // ]);
     
     // When the user refreshes the page, check which of the views was selected and scroll into that
     const selectedView_stored = sessionStorage.getItem('AssocEase_MyProfileSelectedView');

--- a/client/src/components/MyProfile.js
+++ b/client/src/components/MyProfile.js
@@ -256,7 +256,9 @@ function MyProfile(props) {
     // 'fetchUsersEvents'- METHOD AND UNCOMMENT THE LIST CREATION BELOW. THIS FUNCTIONALITY WILL BE
     // DELETED ONCE WE HAVE THE ABILITY TO JOIN EVENTS AND THE "REAL" EVENTS LIST CAN BE SHOWN HERE
 
-    // Fetches the events the user is currently partisipating in
+    // Fetches the events the user is currently participating in
+    // TODO; this currently only includes events the user created themselves
+
     // fetchUsersEvents();
     
     // Create events for testing
@@ -385,7 +387,7 @@ function MyProfile(props) {
                         time={event.time}
                         location={event.location}
                         attendees={event.attendees}
-                        attending={event.attending}
+                        attending={true}
                         description={event.description}
                         key={index}
                         />

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -145,30 +145,29 @@ router.post('/register',
 });
 
 
-router.get('/get/events/for/:id', (req, res) =>
+router.get('/get/events/for/:id', async (req, res) =>
 {
     const id = req.params.id;
-    // Initialize the list where the events will be added
+    // Initialize the lists where the events will be added
     let events = [];
+    let eventIDs = [];
 
-    // Find the events that the user is participating in
-    Member_event.find({member: id})
+    // Find the IDs of the events that the user is participating in
+    await Member_event.find({member: id})
     .then((docs) =>
     {
         docs.forEach(item => {
-            // ID of the event the user is partisipating
-            let eventID = item.event;
-
-            // Get the events
-            Event.find({_id: eventID})
-            .then((docs) =>
-            {
-                docs.forEach(event => {
-                    events.push(event);
-                });
-            })
+            eventIDs.push(item.event);
         });
     });
+
+    // Find the events using the IDs and add to list
+    await Event.find({_id: {$in: eventIDs}})
+    .then((docs) => {
+      docs.forEach(event => {
+        events.push(event);
+      })
+    })
 
     // Returns a list every time. If the user is not partisipating in any events, the list is empty.
     return res.json({events});


### PR DESCRIPTION
Changed some small things I noticed today:
- Async / await for POSTing a new event in the home page, so that we wait until the new event is successfully saved before refreshing the events list. (noticed that sometimes the new event didn't show up in the list and investigated why)
- Changed the logic for searching for a specific user's events slightly in the back-end: made it asynchronous and changed it so that we first find the IDs of the  events the user is participating in, and then use the IDs to find the actual events. Did this because nested `find()` calls don't work well with async / await, and we need async/await to make sure we have all the events before sending the event list back to the client.
- Hard-coded `attending` to be true for events in the My Events -list (so that it looks good for now, will be changed when we have proper attending functionality).

After these changes, if you comment the test event creation and uncomment the fetch method in MyProfile.js, you will be able to see the events you've created yourself in the list (because when you create an event, you're added as a participant in the back-end). Basically we have a bit more to demo now! 

_(Note: The edit and delete buttons don't properly work from the my events list yet, that's something we need to discuss since it involves slightly refactoring how we do the toasts etc.)_

Screenshot:
![image](https://github.com/jannejjj/RASP24/assets/61980297/9c85a59f-f630-4b1e-ab5a-113a3473d20a)
