### PR TITLE
Fix sweetalert2 not found error

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -7,5 +7,6 @@ COPY package-lock.json ./package-lock.json
 
 RUN npm install
 RUN npm install react-scripts@3.3.1 -g --silent
+RUN npm i sweetalert2
 
 COPY . /usr/src/app_client

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -7,6 +7,5 @@ COPY package-lock.json ./package-lock.json
 
 RUN npm install
 RUN npm install react-scripts@3.3.1 -g --silent
-RUN npm i sweetalert2
 
 COPY . /usr/src/app_client

--- a/client/package.json
+++ b/client/package.json
@@ -25,7 +25,8 @@
     "react-toastify": "^10.0.4",
     "styled-components": "^6.1.8",
     "validator": "^13.11.0",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "sweetalert2": "^11.10.6"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,5 @@
     "dev:server": "cd server && npm run dev"
   },
   "author": "Group 4",
-  "license": "ISC",
-  "dependencies": {
-    "sweetalert2": "^11.10.5"
-  }
+  "license": "ISC"
 }


### PR DESCRIPTION
For some reason, sweetalert2 doesn't work properly on the VM unless we install it manually, doing that here. 

EDIT: sweetalert 2 was in the wrong package.json file, it was in root/package.json when it should've been in client/package.json. This should do the trick :D