### PR TITLE
Edit event ticket fix

### DIFF
--- a/client/src/components/EventItem.js
+++ b/client/src/components/EventItem.js
@@ -563,7 +563,7 @@ const handleJoinDeadlineError = (error) => {
                   :
                   (
                     <div>
-                    {typeof tickets !== undefined && tickets !== 0 && tickets - ticketsSold <= 0 ?
+                    {typeof tickets !== "undefined" && tickets !== 0 && tickets - ticketsSold <= 0 ?
                       ( 
                         <Button variant='outlined' disabled color='primary' sx={{width: '150px'}} >Sold Out!</Button>
                       )

--- a/client/src/components/EventItem.js
+++ b/client/src/components/EventItem.js
@@ -54,6 +54,9 @@ function EventItem(props) {
   const [editedLocation, setEditedLocation] = useState(props.event.location);
   const [editedDescription, setEditedDescription] = useState(props.event.description);
 
+  const [ticketSwitchWasToggled, setTicketSwitchWasToggled] = useState(false);
+  const [deadlineSwitchWasToggled, setDeadlineSwitchWasToggled] = useState(false);
+
   const [loadingParticipation, setLoadingParticipation] = useState(true);
   const [loadingLikes, setLoadingLikes] = useState(true);
   
@@ -166,7 +169,8 @@ const savingRules = () => {
   if(endTimeError)  return savingErrorMessages[1];
   if(!checkedDeadline) {
     editedEvent.joinDeadline = undefined;
-  }
+  } else if (!editedEvent.joinDeadline) return savingErrorMessages[2];
+  if(!checkedTicket) editedEvent.tickets = undefined;
   const startDateAux = new Date(editedEvent.startDate);
   const joinDeadlineAux = new Date(editedEvent.joinDeadline);
   const endDateAux = new Date(editedEvent.endDate);
@@ -179,12 +183,9 @@ const savingRules = () => {
   const saveEditedEventOnClick = (e) => {
     e.preventDefault();
     let errorMessage = savingRules();
-    if (errorMessage != ""){
+    if (errorMessage !== ""){
       toasts.showToastMessage(errorMessage);
       return;
-    }
-    if(!checkedDeadline) {
-      editedEvent.joinDeadline = undefined;
     }
     editedEvent.creator = props.currentUser.firstname + " " + props.currentUser.lastname;
     editedEvent.creatorId = props.currentUser.id;
@@ -220,24 +221,14 @@ const savingRules = () => {
     });
   };
 
-//Resets the amount of tickets.
-  const resetTickets = () => {
+  const handleTicketSwitch = () => {
     setCheckedTicket(!checkedTicket);
-    editedEvent.tickets = 0;
-    setEditedEvent(editedEvent);
+    setTicketSwitchWasToggled(!ticketSwitchWasToggled);
   }
 
   const handleDeadlineSwitch = () => {
     setCheckedDeadline(!checkedDeadline);
-    if(checkedDeadline) {
-      editedEvent.joinDeadline = "";
-      setJoinDeadline(undefined);
-    } else {
-      editedEvent.joinDeadline = editedEvent.startDate;
-      setJoinDeadline(editedEvent.startDate); 
-    }
-
-    setEditedEvent(editedEvent);
+    setDeadlineSwitchWasToggled(!deadlineSwitchWasToggled);
   }
 
   //Updates the values for the text fields in event edition
@@ -247,11 +238,13 @@ const savingRules = () => {
 
   const cancelEditOnClick = () => {
     setEditedEvent({});
-    if(!checkedTicket) {
-      resetTickets();
+    if (ticketSwitchWasToggled) {
+      setCheckedTicket(!checkedTicket)
+      setTicketSwitchWasToggled(false);
     }
-    if(checkedDeadline) {
-      handleDeadlineSwitch();
+    if(deadlineSwitchWasToggled) {
+      setCheckedDeadline(!checkedDeadline);
+      setDeadlineSwitchWasToggled(false);
     }
     setEdit(false);
   };
@@ -604,7 +597,7 @@ const handleJoinDeadlineError = (error) => {
           handleStartTimeError={handleStartTimeError}
           handleEndTimeError={handleEndTimeError}
           handleJoinDeadlineError={handleJoinDeadlineError}
-          resetTickets={resetTickets}
+          handleTicketSwitch={handleTicketSwitch}
           handleDeadlineSwitch={handleDeadlineSwitch}
           
           //old values

--- a/client/src/components/EventItem.js
+++ b/client/src/components/EventItem.js
@@ -220,7 +220,7 @@ const savingRules = () => {
     });
   };
 
-//Resets the amount of tickets and clears the text box.
+//Resets the amount of tickets.
   const resetTickets = () => {
     setCheckedTicket(!checkedTicket);
     editedEvent.tickets = 0;

--- a/client/src/components/EventItem.js
+++ b/client/src/components/EventItem.js
@@ -222,7 +222,6 @@ const savingRules = () => {
 
 //Resets the amount of tickets and clears the text box.
   const resetTickets = () => {
-    setTickets("");
     setCheckedTicket(!checkedTicket);
     editedEvent.tickets = 0;
     setEditedEvent(editedEvent);
@@ -241,7 +240,7 @@ const savingRules = () => {
     setEditedEvent(editedEvent);
   }
 
-  //Updates the values for the text fields in event creation
+  //Updates the values for the text fields in event edition
   const whenChanging = (event) => {
     setEditedEvent({...editedEvent, [event.target.id]: event.target.value})
   }
@@ -564,7 +563,7 @@ const handleJoinDeadlineError = (error) => {
                   :
                   (
                     <div>
-                    {typeof tickets !== 'undefined' && tickets - ticketsSold <= 0 ?
+                    {typeof tickets !== undefined && tickets !== 0 && tickets - ticketsSold <= 0 ?
                       ( 
                         <Button variant='outlined' disabled color='primary' sx={{width: '150px'}} >Sold Out!</Button>
                       )

--- a/client/src/modals/EditEventModal.js
+++ b/client/src/modals/EditEventModal.js
@@ -91,7 +91,9 @@ function EditEventModal(props)
                     <Switch checked={props.checkedTicket}/>
                   }
                   label="Limited tickets"
-                  onChange={props.resetTickets}
+                  onChange={() => {
+                    props.handleTicketSwitch();
+                  }}
                 />
                 <TextField 
                   fullWidth 


### PR DESCRIPTION
The problems were to do with us setting `tickets` to "" when the switch is toggled, for the sake of emptying the text field for the number of tickets. This was a problem because when the editing was canceled, there was no way to bring back the old value of `tickets` without refreshing.

I changed it so that we don't do anything to the value of `tickets` when the switch is toggled. This means that the textbox isn't cleared of the amount of tickets when the switch is toggled off, but for me that doesn't seem like a problem, because when the event is saved, the amount of tickets is set to unlimited as it should:
![tickets](https://github.com/jannejjj/RASP24/assets/61980297/1237cea3-67b3-4733-b1cc-1d7caffef0cc)
