### PR TITLE
Fixed reference to location

### DIFF
--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -845,7 +845,7 @@ const CreateAndSendNotifications = async (event) =>
     let message = "Event " + event.title + " updated\n";
     message += "Start time: " + event.startDate + "\n";
     message += "End time: " + event.endDate + "\n";
-    message += "Location: " + event.location + "\n";
+    message += "Location: " + event.location.name + "\n";
     message += "Description: " + event.description + "\n";
 
     // Finally send the reminder about the event


### PR DESCRIPTION
Noticed this issue with event change notification mails and fixed it:
![image](https://github.com/jannejjj/RASP24/assets/61980297/42e8bbc0-5e03-4151-b6a5-f3d15d9ae925)

It was simply the case that with the Google locations we now store the location as an object with a `name` and a `placeId`, and we should reference `name` for it to work correctly :D