### PR TITLE
Ticket / join deadline fixes to event edition

### DIFF
--- a/client/src/components/EventItem.js
+++ b/client/src/components/EventItem.js
@@ -563,7 +563,7 @@ const handleJoinDeadlineError = (error) => {
                   :
                   (
                     <div>
-                    {typeof tickets !== undefined && tickets !== 0 && tickets - ticketsSold <= 0 ?
+                    {typeof tickets !== "undefined" && tickets !== 0 && tickets - ticketsSold <= 0 ?
                       ( 
                         <Button variant='outlined' disabled color='primary' sx={{width: '150px'}} >Sold Out!</Button>
                       )

--- a/client/src/components/EventItem.js
+++ b/client/src/components/EventItem.js
@@ -54,6 +54,9 @@ function EventItem(props) {
   const [editedLocation, setEditedLocation] = useState(props.event.location);
   const [editedDescription, setEditedDescription] = useState(props.event.description);
 
+  const [ticketSwitchWasToggled, setTicketSwitchWasToggled] = useState(false);
+  const [deadlineSwitchWasToggled, setDeadlineSwitchWasToggled] = useState(false);
+
   const [loadingParticipation, setLoadingParticipation] = useState(true);
   const [loadingLikes, setLoadingLikes] = useState(true);
   
@@ -166,7 +169,8 @@ const savingRules = () => {
   if(endTimeError)  return savingErrorMessages[1];
   if(!checkedDeadline) {
     editedEvent.joinDeadline = undefined;
-  }
+  } else if (!editedEvent.joinDeadline) return savingErrorMessages[2];
+  if(!checkedTicket) editedEvent.tickets = undefined;
   const startDateAux = new Date(editedEvent.startDate);
   const joinDeadlineAux = new Date(editedEvent.joinDeadline);
   const endDateAux = new Date(editedEvent.endDate);
@@ -179,12 +183,9 @@ const savingRules = () => {
   const saveEditedEventOnClick = (e) => {
     e.preventDefault();
     let errorMessage = savingRules();
-    if (errorMessage != ""){
+    if (errorMessage !== ""){
       toasts.showToastMessage(errorMessage);
       return;
-    }
-    if(!checkedDeadline) {
-      editedEvent.joinDeadline = undefined;
     }
     editedEvent.creator = props.currentUser.firstname + " " + props.currentUser.lastname;
     editedEvent.creatorId = props.currentUser.id;
@@ -220,24 +221,14 @@ const savingRules = () => {
     });
   };
 
-//Resets the amount of tickets.
-  const resetTickets = () => {
+  const handleTicketSwitch = () => {
     setCheckedTicket(!checkedTicket);
-    editedEvent.tickets = 0;
-    setEditedEvent(editedEvent);
+    setTicketSwitchWasToggled(!ticketSwitchWasToggled);
   }
 
   const handleDeadlineSwitch = () => {
     setCheckedDeadline(!checkedDeadline);
-    if(checkedDeadline) {
-      editedEvent.joinDeadline = "";
-      setJoinDeadline(undefined);
-    } else {
-      editedEvent.joinDeadline = editedEvent.startDate;
-      setJoinDeadline(editedEvent.startDate); 
-    }
-
-    setEditedEvent(editedEvent);
+    setDeadlineSwitchWasToggled(!deadlineSwitchWasToggled);
   }
 
   //Updates the values for the text fields in event edition
@@ -247,11 +238,13 @@ const savingRules = () => {
 
   const cancelEditOnClick = () => {
     setEditedEvent({});
-    if(!checkedTicket) {
-      resetTickets();
+    if (ticketSwitchWasToggled) {
+      setCheckedTicket(!checkedTicket)
+      setTicketSwitchWasToggled(false);
     }
-    if(checkedDeadline) {
-      handleDeadlineSwitch();
+    if(deadlineSwitchWasToggled) {
+      setCheckedDeadline(!checkedDeadline);
+      setDeadlineSwitchWasToggled(false);
     }
     setEdit(false);
   };
@@ -604,7 +597,7 @@ const handleJoinDeadlineError = (error) => {
           handleStartTimeError={handleStartTimeError}
           handleEndTimeError={handleEndTimeError}
           handleJoinDeadlineError={handleJoinDeadlineError}
-          resetTickets={resetTickets}
+          handleTicketSwitch={handleTicketSwitch}
           handleDeadlineSwitch={handleDeadlineSwitch}
           
           //old values

--- a/client/src/components/EventItem.js
+++ b/client/src/components/EventItem.js
@@ -220,7 +220,7 @@ const savingRules = () => {
     });
   };
 
-//Resets the amount of tickets and clears the text box.
+//Resets the amount of tickets.
   const resetTickets = () => {
     setCheckedTicket(!checkedTicket);
     editedEvent.tickets = 0;

--- a/client/src/components/EventItem.js
+++ b/client/src/components/EventItem.js
@@ -222,7 +222,6 @@ const savingRules = () => {
 
 //Resets the amount of tickets and clears the text box.
   const resetTickets = () => {
-    setTickets("");
     setCheckedTicket(!checkedTicket);
     editedEvent.tickets = 0;
     setEditedEvent(editedEvent);
@@ -241,7 +240,7 @@ const savingRules = () => {
     setEditedEvent(editedEvent);
   }
 
-  //Updates the values for the text fields in event creation
+  //Updates the values for the text fields in event edition
   const whenChanging = (event) => {
     setEditedEvent({...editedEvent, [event.target.id]: event.target.value})
   }
@@ -564,7 +563,7 @@ const handleJoinDeadlineError = (error) => {
                   :
                   (
                     <div>
-                    {typeof tickets !== 'undefined' && tickets - ticketsSold <= 0 ?
+                    {typeof tickets !== undefined && tickets !== 0 && tickets - ticketsSold <= 0 ?
                       ( 
                         <Button variant='outlined' disabled color='primary' sx={{width: '150px'}} >Sold Out!</Button>
                       )

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -206,9 +206,6 @@ function Home(props) {
     e.preventDefault()
     if(!startTimeError && newEvent.startDate) {
       if(!endTimeError) {
-        if(!checkedDeadline) {
-          newEvent.joinDeadline = newEvent.startDate;
-        }
         if(!joinDeadlineError && newEvent.joinDeadline && newEvent.joinDeadline <= newEvent.startDate) {
           if(!newEvent.endDate || newEvent.startDate < newEvent.endDate) {
             newEvent.creator = props.currentUser.firstname + " " + props.currentUser.lastname;

--- a/client/src/modals/EditEventModal.js
+++ b/client/src/modals/EditEventModal.js
@@ -91,7 +91,9 @@ function EditEventModal(props)
                     <Switch checked={props.checkedTicket}/>
                   }
                   label="Limited tickets"
-                  onChange={props.resetTickets}
+                  onChange={() => {
+                    props.handleTicketSwitch();
+                  }}
                 />
                 <TextField 
                   fullWidth 


### PR DESCRIPTION
Decided to make a new PR out of this to make it easier to explain the changes :D

So originally I thought the problem was just that events would be shown as sold out after cancelling event edition and needed a page refresh to work again. I discovered that this problem, along with some others, was related to how we handle the switches for the limited number of tickets and event joining deadline.

Changes:
- Created states to keep track of whether or not the switches have been toggled during editing
- Moved away from using the `resetTickets()` function with the tickets switch, it only makes sense in event creation, not edition
- Created a simpler handler for the tickets switch
- When cancelling the edit, the switches are toggled based on the `wasToggled `states
- For simplicity's sake, removed the logic where the starting time of an event would be set as the joining deadline, if no other joining deadline was specified. I think this makes more sense, since if you don't want to specify any joining deadline, it should be possible.
- Also for simplicity, removed the logic where the field would be emptied when the corresponding switch was toggled off

So, now we:
- Keep track of if the switches have been toggled (or more specifically, if they've been toggled an odd number of times since toggling them an even number of times is the same as not toggling them at all). If they have, the switch state is toggled to return it to the starting state when the editing is cancelled.
- Set the joining deadline and/or number of tickets to `undefined` if the corresponding switch hasn't been toggled when saving the edited event. This logic is now in `savingRules()`

# GIFs

Toggling the switches off for an event that has a join deadline and a limited number of tickets:
![switches](https://github.com/jannejjj/RASP24/assets/61980297/0c7be1f2-a425-4150-8c17-1d6ba6ef5b76)


Fiddling with the switches and seeing that they are back in their starting state when editing is cancelled:
![switches_vol2](https://github.com/jannejjj/RASP24/assets/61980297/4f8b440c-c141-48e2-806a-624bcb7dfe37)
