### PR TITLE
Last minute things

### DIFF
--- a/client/src/components/EventItem.js
+++ b/client/src/components/EventItem.js
@@ -9,7 +9,6 @@ GitHub: https://github.com/jannejjj/RASP24
 */
 
 import { React, useEffect, useState } from "react";
-import { ToastContainer, toast } from 'react-toastify';
 import dayjs from 'dayjs';
 // Styles
 import "../styles/HomePage.css";
@@ -59,8 +58,6 @@ function EventItem(props) {
   const [image, setImage] = useState("https://blogs.lut.fi/newcomers/wp-content/uploads/sites/15/2020/02/talvi-ilma-1-1.jpg");
   const [selectedFile, setSelectedFile] = useState(null);
   const [eventParticipantsData, setEventParticipantsData] = useState(null);
-  const [allowDelete, setAllowDelete] = useState(null);
-  const [allowEdit, setAllowEdit] = useState(null);
 
   // These states store the data that is edited
   const [edit, setEdit] = useState(false);
@@ -251,7 +248,7 @@ const savingRules = () => {
         setImage(imageUrl); 
       }
       else{
-        if(response.status == 413){
+        if(response.status === 413){
           toasts.showToastMessage('The image size is too big');
           return;
         }
@@ -590,7 +587,7 @@ const savingRules = () => {
                 (
                   <div>
                     {dayjs(endDate) >= new Date() && <Button className='EditEventButton' variant='contained' onClick={editOnClick} >Edit</Button>}
-                    {(ticketsSold == 0 || props.oldEvent == true) && <Button className='DeleteEventButton' variant='contained' onClick={deleteOnClick} >Delete</Button>}
+                    {(ticketsSold === 0 || props.oldEvent === true) && <Button className='DeleteEventButton' variant='contained' onClick={deleteOnClick} >Delete</Button>}
                     <Tooltip title={"List of event participants"}>
                       <IconButton className="ListParticipantsButton" onClick={openListOnClick}>
                         <PeopleIcon/>
@@ -600,7 +597,7 @@ const savingRules = () => {
                 )
               }
             </div>
-            {props.oldEvent != true &&
+            {props.oldEvent !== true &&
               <div className="RightSideButtons">
                 {like ? 
                   (

--- a/client/src/components/EventItem.js
+++ b/client/src/components/EventItem.js
@@ -156,7 +156,7 @@ function EventItem(props) {
       }
     }
     checkTicket();
-  }, []);
+  }, [props.event]);
 
   // State for event deletion modal
   const [deleteModal, setDeleteModal] = useState(false);
@@ -366,7 +366,7 @@ const savingRules = () => {
       setJoinDeadlineError(true);
     }
   }
-  
+
   // Show edit
   const editOnClick = () => {
     // Set editedEvent to contain the original event data

--- a/client/src/components/EventItem.js
+++ b/client/src/components/EventItem.js
@@ -232,29 +232,29 @@ const savingRules = () => {
         toasts.showToastMessage('Please select a PNG or JPEG image file.');
         return;
       }
-    }
-    //save the image
-    const formData = new FormData();
-    formData.append('image', selectedFile);
-    const response = await fetch(`/api/updateImage/${props.event._id}`, {
-      method: 'POST',
-      body: formData
-    });
-    if(response.ok){
-      const imageData = await response.json(); 
-
-      // Convert the data array to a Uint8Array
-      const uint8Array = new Uint8Array(imageData.buffer.data);
-
-      // Convert the Uint8Array to a Base64 string
-      const base64String = uint8Array.reduce((data, byte) => data + String.fromCharCode(byte), '');
-      const imageUrl = `data:${imageData.mimetype};base64,${btoa(base64String)}`; 
-      setImage(imageUrl); 
-    }
-    else{
-      if(response.status == 413){
-        toasts.showToastMessage('The image size is too big');
-        return;
+      //save the image
+      const formData = new FormData();
+      formData.append('image', selectedFile);
+      const response = await fetch(`/api/updateImage/${props.event._id}`, {
+        method: 'POST',
+        body: formData
+      });
+      if(response.ok){
+        const imageData = await response.json(); 
+  
+        // Convert the data array to a Uint8Array
+        const uint8Array = new Uint8Array(imageData.buffer.data);
+  
+        // Convert the Uint8Array to a Base64 string
+        const base64String = uint8Array.reduce((data, byte) => data + String.fromCharCode(byte), '');
+        const imageUrl = `data:${imageData.mimetype};base64,${btoa(base64String)}`; 
+        setImage(imageUrl); 
+      }
+      else{
+        if(response.status == 413){
+          toasts.showToastMessage('The image size is too big');
+          return;
+        }
       }
     }
 
@@ -342,24 +342,31 @@ const savingRules = () => {
     setEditedEvent({...editedEvent, ["joinDeadline"]: value});
   };
 
-  // Triggered if there is an error in the date formatting
-const handleStartTimeError = (error) => {
-  if(error == "disablePast"){
-    setStartTimeError(false);
-  }else{
-    setStartTimeError(true);
+  // Triggered if there is an error in the dates
+  const handleStartTimeError = (error) => {
+    if(error === null) {
+      setStartTimeError(false);
+    }else{
+      setStartTimeError(true);
+    }
   }
+
+  const handleEndTimeError = (error) => {
+    if (error === null) {
+      setEndTimeError(false);
+    } else {
+      setEndTimeError(true);
+    }
 }
 
-const handleEndTimeError = (error) => {
-  console.log("Ending time error: " + error);
-  setEndTimeError(true);
-}
-
-const handleJoinDeadlineError = (error) => {
-  console.log("Join deadline error: " + error, joinDeadline);
-  setJoinDeadlineError(true);
-} 
+  const handleJoinDeadlineError = (error) => {
+    if (error === null) {
+      setJoinDeadlineError(false);
+    } else {
+      setJoinDeadlineError(true);
+    }
+  }
+  
   // Show edit
   const editOnClick = () => {
     // Set editedEvent to contain the original event data
@@ -470,6 +477,7 @@ const handleJoinDeadlineError = (error) => {
           toasts.showToastSuccessMessage("Payment ok!");
           setTicket(data.ticket);
           setHasTicket(true);
+          setTicketsSold(ticketsSold + 1);
         }
       });
     } catch (error) {

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -202,20 +202,30 @@ function Home(props) {
     setNewEventModal(false);
   };
 
-  // Triggered if there is an error in the date formatting
+
+  // Triggered if there is an error in the dates
   const handleStartTimeError = (error) => {
-    console.log("Starting time error: " + error);
-    setStartTimeError(true);
+    if(error === null) {
+      setStartTimeError(false);
+    }else{
+      setStartTimeError(true);
+    }
   }
 
   const handleEndTimeError = (error) => {
-    console.log("Ending time error: " + error);
-    setEndTimeError(true);
-  }
+    if (error === null) {
+      setEndTimeError(false);
+    } else {
+      setEndTimeError(true);
+    }
+}
 
   const handleJoinDeadlineError = (error) => {
-    console.log("Join deadline error: " + error);
-    setJoinDeadlineError(true);
+    if (error === null) {
+      setJoinDeadlineError(false);
+    } else {
+      setJoinDeadlineError(true);
+    }
   }
 
   // Fetches events from API

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -145,7 +145,7 @@ function Home(props) {
   const resetTickets = () => {
     setTickets("");
     setCheckedTicket(!checkedTicket);
-    newEvent.tickets = 0;
+    newEvent.tickets = undefined;
     setNewEvent(newEvent);
   }
 

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -19,7 +19,6 @@ import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 // Modals, components, and commons
 import CreateEventModal from "../modals/CreateEventModal";
-import EditDetailsModal from "../modals/EditDetailsModal";
 import EventItem from "./EventItem";
 import toasts from "../common/Toast";
 // Icons
@@ -323,7 +322,7 @@ function Home(props) {
               method: 'POST',
               body: formData
             });
-            if(response.status == 413){
+            if(response.status === 413){
               toasts.showToastMessage("The event was created but the image is too big");
               // Empty the input fields
               setNewEvent({});
@@ -422,7 +421,7 @@ function Home(props) {
           <Typography sx={{ mt: 20 }} variant='h4' align="center">{!events?.length>0 && "No events."}</Typography>
         }
 
-        {(props.currentUser.admin && !loading) &&
+        {(props.currentUser.admin && !loading && pastEvents.length > 0) &&
           <div className="HomePastEvents">
             <div className="ShowPastEventsButton" onClick={ShowPastEventsClick}>
               <h3>{showPastEvents ? "Hide" : "Show"} Past Events</h3>

--- a/client/src/components/MyProfile.js
+++ b/client/src/components/MyProfile.js
@@ -688,6 +688,7 @@ function MyProfile(props) {
                       (
                         <EventItem
                         currentUser={props.currentUser}
+                        user={user}
                         event={event}
                         key={index}
                         attending={true}

--- a/client/src/components/Scheduler.js
+++ b/client/src/components/Scheduler.js
@@ -1,6 +1,6 @@
-import { React, useState, useEffect, useMemo, useCallback } from "react";
+import { React, useState, useEffect, useMemo } from "react";
 import "../App.css";
-import { Button, Grid } from '@mui/material';
+import { Grid } from '@mui/material';
 import EventItem from "./EventItem.js";
 import "../styles/Scheduler.css";
 import "../App.css";
@@ -13,7 +13,6 @@ import { Calendar, Views, momentLocalizer} from 'react-big-calendar';
 const localizer = momentLocalizer(moment);
 
 function SchedulerComponent(props) {
-  const [loading, setLoading] = useState(true);
   const [updateEvents, setUpdateEvents] = useState(false);
   const [events, setEvents] = useState([{}]);
   const [calendarEvents, setCalendarEvents] = useState([{}]);
@@ -36,7 +35,6 @@ function SchedulerComponent(props) {
   // Fetches events from API
   useEffect(() => {
     let mounted = true;
-    setLoading(true);
     async function fetchEvents() {
         let url = '/api/events';
         let response = await fetch(url, {headers: {
@@ -46,7 +44,6 @@ function SchedulerComponent(props) {
         let dataJson = await response.json();
         if (mounted) {
             setEvents(dataJson);
-            setLoading(false);
         }
       }
     
@@ -58,7 +55,6 @@ function SchedulerComponent(props) {
           mounted = false;
       };
     }
-    setLoading(false);
   }, [updateEvents]);
 
   useEffect(traduceEvents, [events]);

--- a/client/src/components/Scheduler.js
+++ b/client/src/components/Scheduler.js
@@ -63,6 +63,11 @@ function SchedulerComponent(props) {
 
   useEffect(traduceEvents, [events]);
 
+  const handleOnEditedEvent = () => {
+    setSelectedEvent(null);
+    setUpdateEvents(!updateEvents);
+  }
+
   const handleOnSelectEvent = (e) => {
       setSelectedEvent(events[e.ref]);
   };
@@ -102,7 +107,7 @@ function SchedulerComponent(props) {
                 accordionExpanded={true}
                 showToastMessage={toasts.showToastMessage}
                 showToastSuccessMessage={toasts.showToastSuccessMessage}
-                toggleUpdateEvents={()=>{}}
+                toggleUpdateEvents={handleOnEditedEvent}
                 onDeletedEvent={handleOnDeletedEvent}
                 onEditedEvent={()=>{setUpdateEvents(!updateEvents)}}
               /> :

--- a/client/src/components/Scheduler.js
+++ b/client/src/components/Scheduler.js
@@ -17,6 +17,7 @@ function SchedulerComponent(props) {
   const [events, setEvents] = useState([{}]);
   const [calendarEvents, setCalendarEvents] = useState([{}]);
   const [selectedEvent, setSelectedEvent] = useState(null);
+  const [user, setUser] = useState();
 
   const traduceEvents = ()=>{
     let temp = [];
@@ -32,7 +33,20 @@ function SchedulerComponent(props) {
     setCalendarEvents(temp);
   };
 
-  // Fetches events from API
+  // Get user data
+  const fetchUserData = async () => {
+    try {
+      const response = await fetch(`/users/getData/${props.currentUser.id}`);
+      if (!response.ok) {
+        throw new Error('Failed to fetch user data');
+      }
+      setUser (await response.json()); 
+    } catch (error) {
+      console.error('Error fetching user data:', error);
+    }
+  };
+
+  // Fetches events and user data from API
   useEffect(() => {
     let mounted = true;
     async function fetchEvents() {
@@ -51,6 +65,7 @@ function SchedulerComponent(props) {
     if (props.currentUser.loggedIn)
     {
       fetchEvents();
+      fetchUserData();
       return () => {
           mounted = false;
       };
@@ -97,7 +112,7 @@ function SchedulerComponent(props) {
             {selectedEvent !== null ? 
               <EventItem
                 currentUser={props.currentUser}
-                user={props.currentUser}
+                user={user}
                 admin={props.currentUser.admin}
                 event={selectedEvent}
                 accordionExpanded={true}

--- a/client/src/modals/EditEventModal.js
+++ b/client/src/modals/EditEventModal.js
@@ -45,6 +45,7 @@ function EditEventModal(props)
                   <DateTimePicker 
                     onChange={props.handleStartTimeChange}
                     onError={props.handleStartTimeError}
+                    disablePast={true}
                     label="Select Starting Time" 
                     views={['day', 'month', 'year', 'hours', 'minutes']} 
                     format="DD/MM/YYYY HH:mm"
@@ -74,7 +75,6 @@ function EditEventModal(props)
                     format="DD/MM/YYYY HH:mm"
                     ampm={false}
                     defaultValue={props.joinDeadline !== undefined ? dayjs(props.joinDeadline):null}
-                    value={props.joinDeadline !== undefined ? dayjs(props.joinDeadline):null}
                     sx={{ width: '100%', m: 0.5 }} 
                     slotProps={{
                       textField: {

--- a/client/src/modals/EditEventModal.js
+++ b/client/src/modals/EditEventModal.js
@@ -22,7 +22,6 @@ import AutocompleteInput from '../components/AutocompleteInput';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
-import OutlinedInput from '@mui/material/OutlinedInput'; // TODO: useless?
 import Switch from '@mui/material/Switch';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import { TextField } from '@mui/material';


### PR DESCRIPTION
- Fixed bug related to datetimepickers and errors, basically we had misunderstood how the `onError` prop behaves in DateTimePickers. It returns null when there is no error, when we thought that it wouldn't get fired in the first place if there was no error
- - Added disablePast when editing event start time in the edit modal
- Previously we were sending a request to update the image of an event everytime an event was edited, changed it so that this is only done if an image has been picked in the edit modal
- Fixed a bug where the number of tickets sold for an event didn't update after buying a ticket without a refresh
- Fixed some simple warning from the dev console, such as unused imports
- Fixed a bug where user details were not displayed when buying a ticket from My Profile or the Scheduler 