### PR TITLE
string change

### DIFF
--- a/client/src/modals/CreateEventModal.js
+++ b/client/src/modals/CreateEventModal.js
@@ -120,7 +120,7 @@ function CreateEventModal(props) {
                 />
                 <p className='HintParagraphSmall' >Required *</p>
                 <h2>
-                  Upload profile image
+                  Upload event image
                 </h2>
                 <a>The maximum size is 2MB</a>
                 <div>


### PR DESCRIPTION
When creating an event, the upload image part said upload profile instead of event image
![image](https://github.com/jannejjj/RASP24/assets/61980297/6ca9ea61-2a87-4ae0-8a26-50aba794f9b8)
