### PR TITLE
fixed joinDeadline error after creating a new event

### DIFF
--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -150,10 +150,6 @@ function Home(props) {
 
   const handleDeadlineSwitch = () => {
     setCheckedDeadline(!checkedDeadline);
-    if(!checkedDeadline) {
-      newEvent.joinDeadline = "";
-    }
-    setNewEvent(newEvent);
   }
 
   //Updates the values for the text fields in event creation
@@ -288,6 +284,7 @@ function Home(props) {
           deadlineCorrect = true;
         } else if (!checkedDeadline) {
           deadlineCorrect = true;
+          newEvent.joinDeadline = undefined;
         }
         if(deadlineCorrect) {
           if(!newEvent.endDate || newEvent.startDate < newEvent.endDate) {


### PR DESCRIPTION
- For some reason the joinDeadline was (sometimes???) set to 'null' when creating an event without an ending time. This caused an error when editing. Now the deadline is always set undefined if the switch is not checked.